### PR TITLE
fix: return null on empty caption

### DIFF
--- a/src/scrape.js
+++ b/src/scrape.js
@@ -29,7 +29,7 @@ function getData(body) {
     "posts": graphql.edge_owner_to_timeline_media.edges.map(edge => {
       return {
         "id": edge.node.id,
-        "captionText": edge.node.edge_media_to_caption.edges[0].node.text,
+        "captionText": edge.node.edge_media_to_caption.edges.length === 0 ? null : edge.node.edge_media_to_caption.edges[0].node.text,
         "shortcode": edge.node.shortcode,
         "link": `https://www.instagram.com/p/${edge.node.shortcode}`,
         "commentsCount": edge.node.edge_media_to_comment.count,


### PR DESCRIPTION
In some posts caption is empty so there is an error with undefined index. That is why we check that caption text exists.